### PR TITLE
Fixed Dependency infinate Loop.

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -320,7 +320,6 @@ define KernelPackage/ath11k/Default
   DEPENDS+= +kmod-ath +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT \
   +kmod-crypto-michael-mic +ATH11K_THERMAL:kmod-hwmon-core \
   +ATH11K_THERMAL:kmod-thermal +kmod-qcom-qmi-helpers
-  PROVIDES:=kmod-ath11k
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k.ko
 endef
 
@@ -349,6 +348,7 @@ define KernelPackage/ath11k-smallbuffers
   $(call KernelPackage/ath11k/Default)
   TITLE+= (small buffers for low-RAM devices)
   VARIANT:=smallbuffers
+  PROVIDES:=kmod-ath11k
 endef
 
 define KernelPackage/ath11k-ahb


### PR DESCRIPTION
I have fixed the Kconfig loop in package/kernel/mac80211/ath.mk.

By removing PROVIDES:=kmod-ath11k from the common ath11k/Default definition and moving it to only apply to ath11k-smallbuffers, we prevent Kconfig from erroneously interpreting that kmod-ath11k provides itself.

Moving the `PROVIDES` strictly to the `smallbuffers` variant allows it to act as a drop-in replacement for dependencies cleanly, without crashing Kconfig.